### PR TITLE
Domain Queryable and QueryableSql

### DIFF
--- a/Aspirin.Core/src/URF.Core.Services.DomainModel/DomainService.cs
+++ b/Aspirin.Core/src/URF.Core.Services.DomainModel/DomainService.cs
@@ -4,6 +4,7 @@ using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using AutoMapper;
+using AutoMapper.QueryableExtensions;
 using TrackableEntities.Common.Core;
 using URF.Core.Abstractions;
 using URF.Core.Abstractions.Services.DomainModel;
@@ -110,8 +111,7 @@ namespace URF.Core.Services.DomainModel
             => await Repository.DeleteAsync(keyValue, cancellationToken);
 
         public virtual IQueryable<TDomainModel> Queryable()
-            // TODO: Convert IQuery<TEntity>?
-            => throw new NotImplementedException();
+            => Repository.Queryable().ProjectTo<TDomainModel>(Mapper.ConfigurationProvider);
 
         public virtual IQuery<TDomainModel> Query()
             // TODO: Convert IQuery<TEntity>?

--- a/Aspirin.Core/src/URF.Core.Services.DomainModel/DomainService.cs
+++ b/Aspirin.Core/src/URF.Core.Services.DomainModel/DomainService.cs
@@ -101,7 +101,7 @@ namespace URF.Core.Services.DomainModel
         public virtual void Update(TDomainModel item)
         {
             var entity = Mapper.Map<TDomainModel, TEntity>(item);
-            Repository.Update(entity); ;
+            Repository.Update(entity);
         }
 
         public virtual async Task<bool> DeleteAsync(object[] keyValues, CancellationToken cancellationToken = default)
@@ -113,13 +113,11 @@ namespace URF.Core.Services.DomainModel
         public virtual IQueryable<TDomainModel> Queryable()
             => Repository.Queryable().ProjectTo<TDomainModel>(Mapper.ConfigurationProvider);
 
-        public virtual IQuery<TDomainModel> Query()
-            // TODO: Convert IQuery<TEntity>?
-            => throw new NotImplementedException();
-
         public IQueryable<TDomainModel> QueryableSql(string sql, params object[] parameters)
-            // TODO: Convert IQuery<TEntity>?
-            => throw new NotImplementedException();
+            => Repository.QueryableSql(sql, parameters).ProjectTo<TDomainModel>(Mapper.ConfigurationProvider);
+
+        public virtual IQuery<TDomainModel> Query()
+            => throw new NotSupportedException();
 
         private Expression<Func<TEntity, object>> ConvertPropertyExpression(Expression<Func<TDomainModel, object>> property)
         {

--- a/Aspirin.Core/test/URF.Core.Services.DomainModel.Tests/DomainServiceQueryableTests.cs
+++ b/Aspirin.Core/test/URF.Core.Services.DomainModel.Tests/DomainServiceQueryableTests.cs
@@ -43,9 +43,29 @@ namespace URF.Core.Services.DomainModel.Tests
             const string companyName = "Alfreds Futterkiste";
 
             // Act
-            var query = customerDomainService.Queryable()
-                .Where(x => x.CompanyName.Contains(companyName));
-            var customers = await query.ToListAsync();
+            var query = customerDomainService.Queryable();
+            var customers = await query
+                .Where(x => x.CompanyName.Contains(companyName))
+                .ToListAsync();
+
+            // Assert
+            Assert.Collection(customers, customer
+                => Assert.Equal("ALFKI", customer.CustomerId));
+        }
+
+        [Fact]
+        public async Task QueryableSql_Should_Return_Customer_Query()
+        {
+            // Arrange
+            var customerRepository = new TrackableRepository<Customer>(_fixture.Context);
+            var customerDomainService = new CustomerDomainService(customerRepository, _mapper);
+            const string companyName = "Alfreds Futterkiste";
+
+            // Act
+            var query = customerDomainService.QueryableSql("SELECT * FROM Customers");
+            var customers = await query
+                .Where(x => x.CompanyName.Contains(companyName))
+                .ToListAsync();
 
             // Assert
             Assert.Collection(customers, customer

--- a/Aspirin.Core/test/URF.Core.Services.DomainModel.Tests/DomainServiceQueryableTests.cs
+++ b/Aspirin.Core/test/URF.Core.Services.DomainModel.Tests/DomainServiceQueryableTests.cs
@@ -1,0 +1,55 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using URF.Core.EF.Trackable;
+using URF.Core.Services.DomainModel.Tests.Contexts;
+using URF.Core.Services.DomainModel.Tests.Models;
+using URF.Core.Services.DomainModel.Tests.Services;
+using Xunit;
+
+namespace URF.Core.Services.DomainModel.Tests
+{
+    [Collection(nameof(NorthwindDbContext))]
+    public class DomainServiceQueryableTests
+    {
+        private readonly IMapper _mapper;
+        private readonly NorthwindDbContextFixture _fixture;
+
+        public DomainServiceQueryableTests(NorthwindDbContextFixture fixture)
+        {
+            var customers = Factory.Customers();
+
+            _fixture = fixture;
+            _fixture.Initialize(true, () =>
+            {
+                _fixture.Context.Customers.AddRange(customers);
+                _fixture.Context.SaveChanges();
+            });
+
+            var config = new MapperConfiguration(cfg => {
+                cfg.CreateMap<CustomerDomainModel, Customer>();
+                cfg.CreateMap<Customer, CustomerDomainModel>();
+            });
+            _mapper = config.CreateMapper();
+        }
+
+        [Fact]
+        public async Task Queryable_Should_Return_Customer_Query()
+        {
+            // Arrange
+            var customerRepository = new TrackableRepository<Customer>(_fixture.Context);
+            var customerDomainService = new CustomerDomainService(customerRepository, _mapper);
+            const string companyName = "Alfreds Futterkiste";
+
+            // Act
+            var query = customerDomainService.Queryable()
+                .Where(x => x.CompanyName.Contains(companyName));
+            var customers = await query.ToListAsync();
+
+            // Assert
+            Assert.Collection(customers, customer
+                => Assert.Equal("ALFKI", customer.CustomerId));
+        }
+    }
+}


### PR DESCRIPTION
Use AutoMapper Queryable Extensions to implement Queryable and QueryableSql on DomainService.
- Throw NotSupportedException on DomainService.Query method.